### PR TITLE
getUrls should take a channel ID not the channel itself

### DIFF
--- a/server/methods/read/channels.js
+++ b/server/methods/read/channels.js
@@ -2,19 +2,18 @@ Meteor.methods({
   /*
    * Reads a Channel and searches for its images
    *
-   * @param {Channel} the Channel object to read
+   * @param {channelId} the Channel object to read
    * @param {start_page} the starting page number
    * @param {num_pages} the number of pages to grab images
    * @return {Images} an array of image objects
    */
-  '/channels/getUrls': function(channel) {
+  '/channels/getUrls': function(channelId) {
     // Check Arguments
-    check(channel, Channel);
+    check(channelId, String);
  
     images = [];
-    for (var i = 0; i < 16; i++) {
-      images = images.concat(Modules.server.googleImageSearchSync(channel.get('query')));
-    }
+    images = images.concat(Modules.server.googleImageSearchSync(Channel.findOne(channelId).get('query')));
+
     return images;
   }
 });

--- a/tests/jasmine/server/integration/modules/ImageFetcher_spec.js
+++ b/tests/jasmine/server/integration/modules/ImageFetcher_spec.js
@@ -15,7 +15,7 @@ describe('image fetcher', function() {
     Channel.remove({});
   });
 
-  it('should return 64 urls from the channel query', function() {
+  it('should return 4 urls from the channel query', function() {
     let channel = new Channel({
       title: 'My Test Channel',
       query: 'little flower ponies'
@@ -27,8 +27,8 @@ describe('image fetcher', function() {
       { url: 'www.test.com' },
       { url: 'www.test.com' }
     ]);
-    urls = Meteor.call('/channels/getUrls', channel);
-    expect(urls.length).toEqual(64);
+    urls = Meteor.call('/channels/getUrls', channel._id);
+    expect(urls.length).toEqual(4);
     for (i = 0; i < urls.length; i++) {
       expect(urls[i].url).not.toEqual('');
     }


### PR DESCRIPTION
Because the desktop client cant access astronomy classes, we need to take a channel Id rather than the whole channel itself when getting the urls.

I also reduced the number of channels fetched to 4.